### PR TITLE
Change values of border_size from pixel to image percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ pymarker -m tests/input/hiro.jpg
 $ pymarker --marker tests/input/hiro.jpg
 ```
 
-The marker border size can be adjusted with `-b`, the default value being 84px.
+The marker border size can be adjusted with `-b`, the default value being 50%.
 ```bash
 $ pymarker -b 40 tests/input/hiro.jpg
 ```
@@ -60,7 +60,7 @@ from pymarker.core import generate_patt, generate_marker
 
 def main():
     filename = "tests/input/hiro.jpg"
-    border_size = 84 //size in pixels
+    border_size = 50 // size in percentage
 
     generate_patt(filename)
     generate_marker(filename,border_size)

--- a/pymarker/cli.py
+++ b/pymarker/cli.py
@@ -5,7 +5,7 @@ from .core import generate_marker, generate_patt
 @click.argument('filename')
 @click.option('--patt','-p', is_flag=True, default=False)
 @click.option('--marker','-m', is_flag=True, default=False)
-@click.option('--border-size', '-b', default=84) # 84 is based on template hiro marker
+@click.option('--border-size', '-b', default=50) # 50% is based on template hiro marker
 def generate_patt_and_marker(filename, patt, marker, border_size):
     click.echo("-- Starting PyMarker Generator --".format(filename))
     if (patt and marker) or (not patt and not marker):

--- a/pymarker/core.py
+++ b/pymarker/core.py
@@ -1,10 +1,10 @@
 from .utils import open_image, get_box_coords, remove_extension
 from PIL import Image
+from math import ceil
 
 def get_marker_size(image, border_size):
-    # There are two borders (left and right) and (up and down)
     size = image.height + (border_size*2)
-    # Using the height double because the resulting marker should be a square.
+    # Using the size double because the resulting marker should be a square.
     return (size,size)
 
 def create_empty_patt(filename):
@@ -46,8 +46,11 @@ def color_to_file(c, patt):
                 patt.write(' ')
             n += 1
         
-def generate_marker(filename, border_size):
+def generate_marker(filename, border_percentage):
     image = open_image(filename)
+
+    border_size = ceil(image.height * (border_percentage/100))
+
     # Default color is black, setting (0, 0, 0) for clarity, as the border should be black
     marker_size = get_marker_size(image, border_size)
     marker = Image.new('RGB', marker_size, (0, 0, 0))


### PR DESCRIPTION
This makes it possible to use the marker generator in big images, which didn't fit in the default values set in the generator