### PR TITLE
Add output option

### DIFF
--- a/pymarker/cli.py
+++ b/pymarker/cli.py
@@ -6,11 +6,12 @@ from .core import generate_marker, generate_patt
 @click.option('--patt','-p', is_flag=True, default=False)
 @click.option('--marker','-m', is_flag=True, default=False)
 @click.option('--border-size', '-b', default=50) # 50% is based on template hiro marker
-def generate_patt_and_marker(filename, patt, marker, border_size):
+@click.option('--output','-o', default=None, type=str)
+def generate_patt_and_marker(filename, patt, marker, border_size, output):
     click.echo("-- Starting PyMarker Generator --".format(filename))
     if (patt and marker) or (not patt and not marker):
-        generate_patt(filename)
-        generate_marker(filename, border_size)
+        generate_patt(filename, output)
+        generate_marker(filename, border_size, output)
         click.echo("Generating patt and marker for {}".format(filename))
     elif marker:
         generate_marker(filename, border_size)

--- a/pymarker/cli.py
+++ b/pymarker/cli.py
@@ -14,10 +14,10 @@ def generate_patt_and_marker(filename, patt, marker, border_size, output):
         generate_marker(filename, border_size, output)
         click.echo("Generating patt and marker for {}".format(filename))
     elif marker:
-        generate_marker(filename, border_size)
+        generate_marker(filename, border_size, output)
         click.echo("Generating marker for {}".format(filename))
     elif patt:
-        generate_patt(filename)
+        generate_patt(filename, output)
         click.echo("Generating patt for {}".format(filename))
 
     click.echo("Done.")

--- a/pymarker/core.py
+++ b/pymarker/core.py
@@ -1,4 +1,4 @@
-from .utils import open_image, get_box_coords, remove_extension, get_dir, get_name
+from .utils import open_image, get_box_coords, remove_extension, get_dir, get_name, check_path
 from PIL import Image
 from math import ceil
 
@@ -18,10 +18,10 @@ def generate_patt(filename, output):
     # Patt default marker size is 16x16 pixels
     image = image.resize((16,16))
     
-    output_folder = output if output else get_dir(filename)
+    output = check_path(output) if output else get_dir(filename)
     name = get_name(filename)
 
-    patt_name = create_empty_patt(output_folder+name)
+    patt_name = create_empty_patt(output+name)
     patt = open(patt_name,"a")
     for _ in range(0,4):
         r, g, b = image.split()
@@ -51,7 +51,7 @@ def color_to_file(c, patt):
         
 def generate_marker(filename, border_percentage, output):
     image = open_image(filename)
-    output_folder = output if output else get_dir(filename)
+    output = check_path(output) if output else get_dir(filename)
     name = get_name(filename)
 
     border_size = ceil(image.height * (border_percentage/100))
@@ -60,5 +60,5 @@ def generate_marker(filename, border_percentage, output):
     marker_size = get_marker_size(image, border_size)
     marker = Image.new('RGB', marker_size, (0, 0, 0))
     marker.paste(image,get_box_coords(image,border_size))
-    marker.save(output_folder+name+"_marker.png", "PNG")
+    marker.save(output+name+"_marker.png", "PNG")
     return True

--- a/pymarker/core.py
+++ b/pymarker/core.py
@@ -1,4 +1,4 @@
-from .utils import open_image, get_box_coords, remove_extension
+from .utils import open_image, get_box_coords, remove_extension, get_dir, get_name
 from PIL import Image
 from math import ceil
 
@@ -13,12 +13,15 @@ def create_empty_patt(filename):
     patt_file.close()
     return patt_name
 
-def generate_patt(filename):
+def generate_patt(filename, output):
     image = open_image(filename)
     # Patt default marker size is 16x16 pixels
     image = image.resize((16,16))
     
-    patt_name = create_empty_patt(filename)
+    output_folder = output if output else get_dir(filename)
+    name = get_name(filename)
+
+    patt_name = create_empty_patt(output_folder+name)
     patt = open(patt_name,"a")
     for _ in range(0,4):
         r, g, b = image.split()
@@ -46,8 +49,10 @@ def color_to_file(c, patt):
                 patt.write(' ')
             n += 1
         
-def generate_marker(filename, border_percentage):
+def generate_marker(filename, border_percentage, output):
     image = open_image(filename)
+    output_folder = output if output else get_dir(filename)
+    name = get_name(filename)
 
     border_size = ceil(image.height * (border_percentage/100))
 
@@ -55,5 +60,5 @@ def generate_marker(filename, border_percentage):
     marker_size = get_marker_size(image, border_size)
     marker = Image.new('RGB', marker_size, (0, 0, 0))
     marker.paste(image,get_box_coords(image,border_size))
-    marker.save(remove_extension(filename)+"_marker.png", "PNG")
+    marker.save(output_folder+name+"_marker.png", "PNG")
     return True

--- a/pymarker/utils.py
+++ b/pymarker/utils.py
@@ -42,3 +42,8 @@ def get_dir(filename):
 def get_name(filename):
     name = filename.rsplit("/", 1)[1]
     return name.split(".")[0]
+
+# Check and return folder path with '/' if necessary
+def check_path(path):
+    path = path if path[-1] == "/" else path+"/"
+    return path

--- a/pymarker/utils.py
+++ b/pymarker/utils.py
@@ -31,3 +31,14 @@ def get_box_coords(image, border_size):
 # The filename contains extension and/or folders that should be filtered
 def remove_extension(filename):
     return filename.split(".")[0]
+
+# Get folder location of file
+def get_dir(filename):
+    # Avoid error on paths without '/' at the end
+    folder = filename if filename[-1] == "/" else filename+"/"
+    return folder.rsplit("/", 2)[0]+"/"
+
+# Get name of the file from a filepath
+def get_name(filename):
+    name = filename.rsplit("/", 1)[1]
+    return name.split(".")[0]


### PR DESCRIPTION
This PR close #3 
Now it's possible to receive the -o flag with an output folder and stick with the current behavior without it.
There's no need to end the output path with slash mark __/__

```
pymarker /tests/input/hiro.jpg -o /tests/output/
pymarker /tests/input/hiro.jpg --output /tests/output
```