### PR TITLE
Enable pymarker to be used with redirect operators of Unix

### DIFF
--- a/pymarker/__init__.py
+++ b/pymarker/__init__.py
@@ -1,2 +1,3 @@
 from .core import *
 from .cli import *
+from .utils import *

--- a/pymarker/cli.py
+++ b/pymarker/cli.py
@@ -2,21 +2,22 @@ import click
 from .core import generate_marker, generate_patt
 from .utils import echo
 
+
 @click.command()
-@click.argument('filename')
-@click.option('--patt','-p', is_flag=True, default=False)
-@click.option('--marker','-m', is_flag=True, default=False)
-@click.option('--string','-s', is_flag=True, default=False)
-@click.option('--border-size', '-b', default=50) # 50% is based on template hiro marker
-@click.option('--output','-o', default=None, type=str)
+@click.argument("filename")
+@click.option("--patt", "-p", is_flag=True, default=False)
+@click.option("--marker", "-m", is_flag=True, default=False)
+@click.option("--string", "-s", is_flag=True, default=False)
+@click.option("--border-size", "-b", default=50)  # 50% is based on template hiro marker
+@click.option("--output", "-o", default=None, type=str)
 def generate_patt_and_marker(filename, patt, marker, string, border_size, output):
     echo("-- Starting PyMarker Generator --".format(filename), silent=string)
     if (patt and marker) or (not patt and not marker):
-        echo("Generating patt and marker for {}".format(filename),silent=string)
+        echo("Generating patt and marker for {}".format(filename), silent=string)
         generate_patt(filename, output, string)
         generate_marker(filename, border_size, output)
     elif marker:
-        echo("Generating marker for {}".format(filename),silent=string)
+        echo("Generating marker for {}".format(filename), silent=string)
         generate_marker(filename, border_size, output)
     elif patt:
         echo("Generating patt for {}".format(filename), silent=string)
@@ -24,8 +25,10 @@ def generate_patt_and_marker(filename, patt, marker, string, border_size, output
 
     echo("Done.", silent=string)
 
+
 def main():
     generate_patt_and_marker()
+
 
 if __name__ == "__main__":
     main()

--- a/pymarker/cli.py
+++ b/pymarker/cli.py
@@ -1,5 +1,6 @@
 import click
 from .core import generate_marker, generate_patt
+from .utils import echo
 
 @click.command()
 @click.argument('filename')
@@ -9,19 +10,19 @@ from .core import generate_marker, generate_patt
 @click.option('--border-size', '-b', default=50) # 50% is based on template hiro marker
 @click.option('--output','-o', default=None, type=str)
 def generate_patt_and_marker(filename, patt, marker, string, border_size, output):
-    click.echo("-- Starting PyMarker Generator --".format(filename))
+    echo("-- Starting PyMarker Generator --".format(filename), silent=string)
     if (patt and marker) or (not patt and not marker):
-        click.echo("Generating patt and marker for {}".format(filename))
+        echo("Generating patt and marker for {}".format(filename),silent=string)
         generate_patt(filename, output, string)
         generate_marker(filename, border_size, output)
     elif marker:
-        click.echo("Generating marker for {}".format(filename))
+        echo("Generating marker for {}".format(filename),silent=string)
         generate_marker(filename, border_size, output)
     elif patt:
-        click.echo("Generating patt for {}".format(filename))
+        echo("Generating patt for {}".format(filename), silent=string)
         generate_patt(filename, output, string)
 
-    click.echo("Done.")
+    echo("Done.", silent=string)
 
 def main():
     generate_patt_and_marker()

--- a/pymarker/core.py
+++ b/pymarker/core.py
@@ -13,7 +13,11 @@ def create_empty_patt(filename):
     patt_file.close()
     return patt_name
 
-def generate_patt(filename, output, string):
+def create_and_open_patt(filename):
+    patt_name = create_empty_patt(filename)
+    return open(patt_name,"a")
+
+def generate_patt(filename, output, string=False):
     image = open_image(filename)
     # Patt default marker size is 16x16 pixels
     image = image.resize((16,16))
@@ -21,8 +25,7 @@ def generate_patt(filename, output, string):
     output = check_path(output) if output else get_dir(filename)
     name = get_name(filename)
 
-    patt_name = create_empty_patt(output+name)
-    patt = PattStr() if string else open(patt_name,"a")
+    patt = PattStr() if string else create_and_open_patt(output+name)
     for _ in range(0,4):
         r, g, b = image.split()
         color_to_file(r, patt)

--- a/pymarker/core.py
+++ b/pymarker/core.py
@@ -1,67 +1,82 @@
-from .utils import open_image, get_box_coords, remove_extension, get_dir, get_name, check_path, PattStr
+from .utils import (
+    open_image,
+    get_box_coords,
+    remove_extension,
+    get_dir,
+    get_name,
+    check_path,
+    PattStr,
+)
 from PIL import Image
 from math import ceil
 
+
 def get_marker_size(image, border_size):
-    size = image.height + (border_size*2)
+    size = image.height + (border_size * 2)
     # Using the size double because the resulting marker should be a square.
-    return (size,size)
+    return (size, size)
+
 
 def create_empty_patt(filename):
-    patt_name = remove_extension(filename)+".patt"
+    patt_name = remove_extension(filename) + ".patt"
     patt_file = open(patt_name, "w")
     patt_file.close()
     return patt_name
 
+
 def create_and_open_patt(filename):
     patt_name = create_empty_patt(filename)
-    return open(patt_name,"a")
+    return open(patt_name, "a")
+
 
 def generate_patt(filename, output, string=False):
     image = open_image(filename)
     # Patt default marker size is 16x16 pixels
-    image = image.resize((16,16))
-    
+    image = image.resize((16, 16))
+
     output = check_path(output) if output else get_dir(filename)
     name = get_name(filename)
 
-    patt = PattStr() if string else create_and_open_patt(output+name)
-    for _ in range(0,4):
+    patt = PattStr() if string else create_and_open_patt(output + name)
+    for _ in range(0, 4):
         r, g, b = image.split()
         color_to_file(r, patt)
         color_to_file(g, patt)
         color_to_file(b, patt)
-        patt.write('\n')
+        patt.write("\n")
         image = image.rotate(90)
 
     patt.close()
     return True
 
+
 def patt_number_format(point):
-    return str(point).rjust(3,' ')    
+    return str(point).rjust(3, " ")
+
 
 # Prints all pixels from a split color to the patt file
 def color_to_file(c, patt):
-        n = 1
-        for point in list(c.getdata()):
-            patt.write(patt_number_format(point))
-            if(n != 0 and n % 16 == 0):
-                n = 0
-                patt.write('\n')
-            else:
-                patt.write(' ')
-            n += 1
-        
+    n = 1
+    for point in list(c.getdata()):
+        patt.write(patt_number_format(point))
+        if n != 0 and n % 16 == 0:
+            n = 0
+            patt.write("\n")
+        else:
+            patt.write(" ")
+        n += 1
+
+
 def generate_marker(filename, border_percentage, output):
     image = open_image(filename)
     output = check_path(output) if output else get_dir(filename)
     name = get_name(filename)
 
-    border_size = ceil(image.height * (border_percentage/100))
+    border_size = ceil(image.height * (border_percentage / 100))
 
     # Default color is black, setting (0, 0, 0) for clarity, as the border should be black
     marker_size = get_marker_size(image, border_size)
-    marker = Image.new('RGB', marker_size, (0, 0, 0))
-    marker.paste(image,get_box_coords(image,border_size))
-    marker.save(output+name+"_marker.png", "PNG")
+    marker = Image.new("RGB", marker_size, (0, 0, 0))
+    marker.paste(image, get_box_coords(image, border_size))
+    marker.save(output + name + "_marker.png", "PNG")
     return True

--- a/pymarker/utils.py
+++ b/pymarker/utils.py
@@ -1,5 +1,6 @@
 import os 
 from PIL import Image
+import click
 
 def get_current_dir():
     # Slash added at the end to append with filenames
@@ -48,16 +49,20 @@ def check_path(path):
     path = path if path[-1] == "/" else path+"/"
     return path
 
+def echo(string, silent=False, *params, **kwargs):
+    if not silent:
+        click.echo(string, *params, **kwargs)
+
 class PattStr:
 
     def __init__(self):
        self.content = ''
 
     def __repr__(self):
-        return self.content
+        return self.content.rstrip()
 
     def write(self, data):
         self.content += data
 
     def close(self):
-        print(self)
+        echo(self)

--- a/pymarker/utils.py
+++ b/pymarker/utils.py
@@ -1,62 +1,71 @@
-import os 
+import os
 from PIL import Image
 import click
 
+
 def get_current_dir():
     # Slash added at the end to append with filenames
-    return os.path.abspath('.') + '/'
+    return os.path.abspath(".") + "/"
+
 
 def open_image(filename):
-    image_path = get_current_dir() + filename    
+    image_path = get_current_dir() + filename
     try:
         image = Image.open(image_path)
     except IOError:
         raise FileNotFoundError
-    
+
     return square_image(image)
 
+
 def square_image(image):
-    limited_size = image.width if image.height>image.width else image.height
-    return image.resize((limited_size,limited_size))
-    
+    limited_size = image.width if image.height > image.width else image.height
+    return image.resize((limited_size, limited_size))
+
+
 # Coords used when pasting the original image inside the black canvas to create borders
 def get_box_coords(image, border_size):
     # left, upper, right, lower bounds in pixels
-    return (border_size,
-            border_size, 
-            border_size + image.width,
-            border_size + image.height
-            )
+    return (
+        border_size,
+        border_size,
+        border_size + image.width,
+        border_size + image.height,
+    )
 
 
 # The filename contains extension and/or folders that should be filtered
 def remove_extension(filename):
     return filename.split(".")[0]
 
+
 # Get folder location of file
 def get_dir(filename):
     # Avoid error on paths without '/' at the end
-    folder = filename if filename[-1] == "/" else filename+"/"
-    return folder.rsplit("/", 2)[0]+"/"
+    folder = filename if filename[-1] == "/" else filename + "/"
+    return folder.rsplit("/", 2)[0] + "/"
+
 
 # Get name of the file from a filepath
 def get_name(filename):
     name = filename.rsplit("/", 1)[1]
     return name.split(".")[0]
 
+
 # Check and return folder path with '/' if necessary
 def check_path(path):
-    path = path if path[-1] == "/" else path+"/"
+    path = path if path[-1] == "/" else path + "/"
     return path
+
 
 def echo(string, silent=False, *params, **kwargs):
     if not silent:
         click.echo(string, *params, **kwargs)
 
-class PattStr:
 
+class PattStr:
     def __init__(self):
-       self.content = ''
+        self.content = ""
 
     def __repr__(self):
         return self.content.rstrip()

--- a/setup.py
+++ b/setup.py
@@ -5,28 +5,24 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pymarker",
-    version="0.1.0",
+    version="0.2.0",
     author="Pablo Silva",
     author_email="pablodiegoss@hotmail.com",
     description="A python package to generate AR markers and patterns based on input images",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    keywords='AR pattern markers jandig hiro',
+    keywords="AR pattern markers jandig hiro",
     url="https://github.com/pablodiegoss/pymarker",
     packages=setuptools.find_packages(),
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
-    entry_points = {
-        'console_scripts': ['pymarker=pymarker.cli:main'],
+    entry_points={
+        "console_scripts": ["pymarker=pymarker.cli:main"],
     },
-    install_requires=[
-        'click==7.1.1',
-        'pillow==7.1.0'
-    ],
-    python_requires='>=3.5',
+    install_requires=["click>=7.1.1", "pillow>=7.1.0"],
+    python_requires=">=3.5",
 )
-


### PR DESCRIPTION
When used with the flag -s, now pymarker patt output can be used with `>` operator of Unix, as such:

`pymarker -s tests/input/hiro.jpg > tests/output/teste_string.patt`

This will result in a correctly formatted patt file as all of the other outputs from pymarker where silenced when using `--string` flag
