### PR TITLE
Fix marker generator for transparent images

### DIFF
--- a/pymarker/core.py
+++ b/pymarker/core.py
@@ -72,16 +72,20 @@ def color_to_file(c, patt):
 
 def generate_marker(filename, border_percentage=50, output=None):
     if filename:
-        image = open_image(filename)
+        image = open_image(filename).convert("RGBA")
         output = check_path(output) if output else get_dir(filename)
         name = get_name(filename)
 
         border_size = ceil(image.height * (border_percentage / 100))
 
+        image_width, image_height = image.size
+        white_image = Image.new("RGBA", image.size, "WHITE")
+        white_image.paste(image, (0, 0, image_width, image_height), image)
+
         # Default color is black, setting (0, 0, 0) for clarity, as the border should be black
-        marker_size = get_marker_size(image, border_size)
-        marker = Image.new("RGB", marker_size, (0, 0, 0))
-        marker.paste(image, get_box_coords(image, border_size))
+        marker_size = get_marker_size(white_image, border_size)
+        marker = Image.new("RGBA", marker_size, (0, 0, 0))
+        marker.paste(white_image, get_box_coords(white_image, border_size))
         marker.save(output + name + "_marker.png", "PNG")
     else:
         raise FileNotFoundError

--- a/pymarker/core.py
+++ b/pymarker/core.py
@@ -69,23 +69,28 @@ def color_to_file(c, patt):
             patt.write(" ")
         n += 1
 
+def generate_white_background(image):
+    if len(image.split()) > 3:
+        image_width, image_height = image.size
+        white_image = Image.new("RGB", image.size, (255,255,255))
+        white_image.paste(image, mask=image.split()[3])
+        return white_image
+    return image
 
 def generate_marker(filename, border_percentage=50, output=None):
     if filename:
-        image = open_image(filename).convert("RGBA")
+        image = open_image(filename)
         output = check_path(output) if output else get_dir(filename)
         name = get_name(filename)
 
         border_size = ceil(image.height * (border_percentage / 100))
 
-        image_width, image_height = image.size
-        white_image = Image.new("RGBA", image.size, "WHITE")
-        white_image.paste(image, (0, 0, image_width, image_height), image)
+        new_image = generate_white_background(image)
 
         # Default color is black, setting (0, 0, 0) for clarity, as the border should be black
-        marker_size = get_marker_size(white_image, border_size)
-        marker = Image.new("RGBA", marker_size, (0, 0, 0))
-        marker.paste(white_image, get_box_coords(white_image, border_size))
+        marker_size = get_marker_size(new_image, border_size)
+        marker = Image.new("RGB", marker_size, (0, 0, 0))
+        marker.paste(new_image, get_box_coords(new_image, border_size))
         marker.save(output + name + "_marker.png", "PNG")
     else:
         raise FileNotFoundError

--- a/pymarker/core.py
+++ b/pymarker/core.py
@@ -38,15 +38,17 @@ def generate_patt(filename, output=None, string=False):
         output = check_path(output) if output else get_dir(filename)
         name = get_name(filename)
 
+        new_image = generate_white_background(image)
+
         patt = PattStr() if string else create_and_open_patt(output + name)
         for i in range(0, 4):
-            r, g, b = image.split()
+            r, g, b = new_image.split()
             color_to_file(r, patt)
             color_to_file(g, patt)
             color_to_file(b, patt)
             if i != 3:
                 patt.write("\n")
-            image = image.rotate(90)
+            new_image = new_image.rotate(90)
 
         return patt.close()
     else:

--- a/pymarker/core.py
+++ b/pymarker/core.py
@@ -71,13 +71,15 @@ def color_to_file(c, patt):
             patt.write(" ")
         n += 1
 
+
 def generate_white_background(image):
     if len(image.split()) > 3:
         image_width, image_height = image.size
-        white_image = Image.new("RGB", image.size, (255,255,255))
+        white_image = Image.new("RGB", image.size, (255, 255, 255))
         white_image.paste(image, mask=image.split()[3])
         return white_image
     return image
+
 
 def generate_marker(filename, border_percentage=50, output=None):
     if filename:


### PR DESCRIPTION
## Description

This Pull Request solve the bug for sending transparent images.

Now this is how he handles transparent images.

Image:
![sleep](https://user-images.githubusercontent.com/35435199/101286481-87b9ff80-37c9-11eb-88a5-4fea4e6260e0.png)

Marker:
![sleep_marker](https://user-images.githubusercontent.com/35435199/101286487-8dafe080-37c9-11eb-9eb0-fd81f03314cc.png)

## Resolves (Issues)

#11 

## General tasks performed
- [x] Detect if the image contains alpha field in its composition
- [x] Create a white background for the transparent image

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).

- [x] Yes
- [ ] No